### PR TITLE
Build Linux NARs with ubuntu-18.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   build-linux:
     name: Build for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.liblouis</groupId>
 	<artifactId>louis</artifactId>
-	<version>3.24.0-p1</version>
+	<version>3.24.0-p2-SNAPSHOT</version>
 	<packaging>nar</packaging>
 	<name>liblouis-nar</name>
 	<description>liblouis packaged in a NAR (Native ARchive).</description>


### PR DESCRIPTION
so that the .so can be used on systems with an older glibc

see https://github.com/liblouis/liblouis-nar/issues/9